### PR TITLE
feat: load endpoints `from_env()`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1671,7 +1671,7 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 [[package]]
 name = "streamstore"
 version = "0.1.0"
-source = "git+https://github.com/s2-streamstore/s2-sdk-rust.git?branch=main#326610dfd4229a8d66c4429ec7820c8f83636290"
+source = "git+https://github.com/s2-streamstore/s2-sdk-rust.git?rev=54e36154a1aaf9ead2512bb446677cb7e94a4dc2#54e36154a1aaf9ead2512bb446677cb7e94a4dc2"
 dependencies = [
  "backon",
  "bytesize",
@@ -1733,7 +1733,7 @@ dependencies = [
 [[package]]
 name = "sync_docs"
 version = "0.1.0"
-source = "git+https://github.com/s2-streamstore/s2-sdk-rust.git?branch=main#326610dfd4229a8d66c4429ec7820c8f83636290"
+source = "git+https://github.com/s2-streamstore/s2-sdk-rust.git?rev=54e36154a1aaf9ead2512bb446677cb7e94a4dc2#54e36154a1aaf9ead2512bb446677cb7e94a4dc2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ pin-project-lite = "0.2"
 pin-utils = "0.1.0"
 serde = { version = "1.0.214", features = ["derive"] }
 serde_json = "1.0.132"
-streamstore = { git = "https://github.com/s2-streamstore/s2-sdk-rust.git", branch = "main" }
+streamstore = { git = "https://github.com/s2-streamstore/s2-sdk-rust.git", rev = "54e36154a1aaf9ead2512bb446677cb7e94a4dc2" }
 thiserror = "1.0.67"
 tokio = { version = "*", features = ["full"] }
 tokio-stream = { version = "0.1.16", features = ["io-util"] }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,5 @@
 use miette::Diagnostic;
-use streamstore::client::ClientError;
+use streamstore::client::{ClientError, InvalidHostError};
 use thiserror::Error;
 
 use crate::{
@@ -31,6 +31,10 @@ pub enum S2CliError {
     #[error("Failed to connect to s2: {0}")]
     #[diagnostic(help("Are you connected to the internet?"))]
     Connection(#[from] ClientError),
+
+    #[error("{0}")]
+    #[diagnostic(help("Are you overriding `S2_CLOUD`, `S2_CELL`, or `S2_BASIN_ZONE`?"))]
+    InvalidHost(#[from] InvalidHostError),
 
     #[error(transparent)]
     #[diagnostic(help("{}", HELP))]


### PR DESCRIPTION
It'll still default to prod in AWS

Also start to reference git rev for the SDK dependency for determinism.