### PR TITLE
fix: flush BufWriter

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -251,7 +251,7 @@ impl RecordsIO {
             RecordsIO::Stdout => {
                 trace!("stdout writer");
                 Ok(Box::new(BufWriter::new(tokio::io::stdout())))
-            },
+            }
             RecordsIO::Stdin => panic!("unsupported record source"),
         }
     }


### PR DESCRIPTION
This wasn't happening before, so stdout / file was never getting the content of records.

From tokio [docs](https://docs.rs/tokio/latest/tokio/io/struct.BufWriter.html):
> When the BufWriter is dropped, the contents of its buffer will be discarded. Creating multiple instances of a BufWriter on the same stream can cause data loss. If you need to write out the contents of its buffer, you must manually call flush before the writer is dropped.