### PR TITLE
fix: Optional `start_seq_num` in `StreamService/ReadSession`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -231,7 +231,7 @@ enum StreamActions {
     Read {
         /// Starting sequence number (inclusive). If not specified, the latest record.
         #[arg(short = 's', long)]
-        start_seq_num: u64,
+        start_seq_num: Option<u64>,
 
         /// Output records to a file or stdout.
         /// Use "-" to write to stdout.

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -88,12 +88,12 @@ impl StreamService {
 
     pub async fn read_session(
         &self,
-        start_seq_num: u64,
+        start_seq_num: Option<u64>,
         limit_count: Option<u64>,
         limit_bytes: Option<u64>,
     ) -> Result<Streaming<ReadOutput>, ServiceError> {
         let read_session_req = ReadSessionRequest {
-            start_seq_num: Some(start_seq_num),
+            start_seq_num,
             limit: match (limit_count, limit_bytes) {
                 (Some(count), Some(bytes)) => Some(ReadLimit { count, bytes }),
                 (Some(count), None) => Some(ReadLimit { count, bytes: 0 }),


### PR DESCRIPTION
So we can start reading from latest.