### PR TITLE
fix: ls to return fully qualified s2 uri

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -563,7 +563,7 @@ async fn run() -> Result<(), S2CliError> {
             (Some(s), None) | (None, Some(s)) => Some(s),
             (None, None) => None,
         };
-        let basin_client = BasinClient::new(client_config, basin);
+        let basin_client = BasinClient::new(client_config, basin.clone());
         let streams = BasinService::new(basin_client)
             .list_streams(
                 prefix.unwrap_or_default(),
@@ -582,7 +582,8 @@ async fn run() -> Result<(), S2CliError> {
             };
 
             println!(
-                "{} {} {}",
+                "s2://{}/{} {} {}",
+                basin,
                 name,
                 date_time(created_at).to_string().green(),
                 deleted_at


### PR DESCRIPTION
Minor improvement:
```console
% s2 ls my-basin
s2://my-basin/chat/general 2025-02-20T19:40:37Z
s2://my-basin/my-express-stream 2024-12-19T08:12:52Z
```

instead of
```console
% s2 ls my-basin
chat/general 2025-02-20T19:40:37Z
my-express-stream 2024-12-19T08:12:52Z
```

makes it easier to copy-paste the url and immediately `s2 read` or etc on it 