### PR TITLE
feat: auto-paginate for stream and basin list

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1667,6 +1667,7 @@ dependencies = [
 name = "streamstore-cli"
 version = "0.8.4"
 dependencies = [
+ "async-stream",
  "base64ct",
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ name = "s2"
 path = "src/main.rs"
 
 [dependencies]
+async-stream = "0.3.6"
 base64ct = { version = "1.6.0", features = ["alloc"] }
 bytes = "1.9.0"
 clap = { version = "4.5.27", features = ["derive"] }
@@ -34,7 +35,6 @@ tokio-stream = { version = "0.1.17", features = ["io-util"] }
 toml = "0.8.19"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
-async-stream = "0.3.6"
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ tokio-stream = { version = "0.1.17", features = ["io-util"] }
 toml = "0.8.19"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+async-stream = "0.3.6"
 
 [profile.release]
 lto = true


### PR DESCRIPTION
Adds functionality to automatically follow pagination (`has_more`) responses on lists for stream and basin, and enables it by default.

The relevant commands (`ls`, `list-streams`, `list-basins`) now accept a `--no-auto-paginate` flag to disable.

```console
% s2 ls s2://eventlog-123 | wc -l
    2004

% s2 ls s2://eventlog-123 --limit 1500 | wc -l
    1500

% s2 ls s2://eventlog-123 --limit 1500 --no-auto-paginate | wc -l
    1000
```

If we add another paginated type we should probably create a trait (in the rust SDK) and make the follow fn generic.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add auto-pagination for stream and basin lists with a flag to disable it.
> 
>   - **Behavior**:
>     - Auto-pagination added for `list_basins` in `AccountService` and `list_streams` in `BasinService`.
>     - New `--no-auto-paginate` flag in `Commands::Ls`, `Commands::ListBasins`, and `Commands::ListStreams` to disable auto-pagination.
>   - **Dependencies**:
>     - Added `async-stream` to `Cargo.toml` and `Cargo.lock`.
>   - **Functions**:
>     - Modified `list_basins` in `account.rs` and `list_streams` in `basin.rs` to use `async-stream` for pagination.
>     - Updated `list_basins` and `list_streams` functions in `main.rs` to handle streams with auto-pagination.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=s2-streamstore%2Fs2-cli&utm_source=github&utm_medium=referral)<sup> for da14ddd233bdd86203c17df5cddaf09279deffc0. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->