### PR TITLE
chore(release): 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.9.0] - 2025-03-12
+
+### Features
+
+- Auto-paginate for stream and basin list ([#128](https://github.com/s2-streamstore/s2-cli/issues/128))
+
+### Bug Fixes
+
+- Ls to return fully qualified s2 uri ([#126](https://github.com/s2-streamstore/s2-cli/issues/126))
+
+### Miscellaneous Tasks
+
+- Remove unused deps + bump sdk version ([#125](https://github.com/s2-streamstore/s2-cli/issues/125))
+- *(release)* Upgrade SDK ([#129](https://github.com/s2-streamstore/s2-cli/issues/129))
+
 ## [0.8.4] - 2025-02-05
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1688,7 +1688,7 @@ dependencies = [
 
 [[package]]
 name = "streamstore-cli"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "async-stream",
  "base64ct",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "streamstore-cli"
 description = "CLI for S2"
-version = "0.8.4"
+version = "0.9.0"
 edition = "2024"
 license = "Apache-2.0"
 keywords = ["streamstore", "s2", "log", "stream", "s3"]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Bump `streamstore-cli` version to 0.9.0 with new features, bug fixes, and SDK upgrades.
> 
>   - **Version Update**:
>     - Bump version from `0.8.4` to `0.9.0` in `Cargo.toml` and `Cargo.lock`.
>   - **Features**:
>     - Add auto-pagination for stream and basin list.
>   - **Bug Fixes**:
>     - Update `ls` command to return fully qualified s2 URI.
>   - **Miscellaneous**:
>     - Remove unused dependencies and bump SDK version.
>     - Upgrade SDK for release.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=s2-streamstore%2Fs2-cli&utm_source=github&utm_medium=referral)<sup> for 0b22f284822a0d4b8e56ed437cccc60a770382f4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->