### PR TITLE
fix: `--create-stream-on-append` to accept explicit bool

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -683,7 +683,7 @@ async fn run() -> Result<(), S2CliError> {
                     basin.into(),
                     storage_class,
                     retention_policy,
-                    config.create_stream_on_append,
+                    config.create_stream_on_append.unwrap_or_default(),
                 )
                 .await?;
 
@@ -724,7 +724,9 @@ async fn run() -> Result<(), S2CliError> {
                     mask.push("default_stream_config.retention_policy".to_owned());
                 }
             }
-
+            if config.create_stream_on_append.is_some() {
+                mask.push("create_stream_on_append".to_owned());
+            }
             let config: BasinConfig = account_service
                 .reconfigure_basin(basin.into(), config.into(), mask)
                 .await?

--- a/src/types.rs
+++ b/src/types.rs
@@ -146,7 +146,7 @@ pub struct BasinConfig {
     pub default_stream_config: Option<StreamConfig>,
     /// Create stream on append with basin defaults if it doesn't exist.
     #[arg(short = 'c', long)]
-    pub create_stream_on_append: bool,
+    pub create_stream_on_append: Option<bool>,
 }
 
 #[derive(Parser, Debug, Clone, Serialize)]
@@ -190,7 +190,7 @@ impl From<BasinConfig> for s2::types::BasinConfig {
         } = config;
         s2::types::BasinConfig {
             default_stream_config: default_stream_config.map(Into::into),
-            create_stream_on_append,
+            create_stream_on_append: create_stream_on_append.unwrap_or_default(),
         }
     }
 }
@@ -252,7 +252,7 @@ impl From<s2::types::BasinConfig> for BasinConfig {
     fn from(config: s2::types::BasinConfig) -> Self {
         BasinConfig {
             default_stream_config: config.default_stream_config.map(Into::into),
-            create_stream_on_append: config.create_stream_on_append,
+            create_stream_on_append: Some(config.create_stream_on_append),
         }
     }
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change `create_stream_on_append` in `BasinConfig` to `Option<bool>` to allow explicit `None`, defaulting to `false`.
> 
>   - **Behavior**:
>     - `create_stream_on_append` in `BasinConfig` changed from `bool` to `Option<bool>` in `types.rs`.
>     - Defaults to `false` if `None` in `run()` in `main.rs` and `From<BasinConfig>` in `types.rs`.
>     - Updates `mask` in `run()` in `main.rs` to include `create_stream_on_append` if set.
>   - **Misc**:
>     - Adjusts `From<BasinConfig>` and `From<s2::types::BasinConfig>` implementations in `types.rs` to handle `Option<bool>`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=s2-streamstore%2Fs2-cli&utm_source=github&utm_medium=referral)<sup> for 8bd71e810189868afcab30e53597c14ee96d5fd2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->