### PR TITLE
chore(release): 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.10.0] - 2025-03-14
+
+### Bug Fixes
+
+- `--create-stream-on-append` to accept explicit bool ([#131](https://github.com/s2-streamstore/s2-cli/issues/131))
+
 ## [0.9.0] - 2025-03-12
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1688,7 +1688,7 @@ dependencies = [
 
 [[package]]
 name = "streamstore-cli"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "async-stream",
  "base64ct",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "streamstore-cli"
 description = "CLI for S2"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 license = "Apache-2.0"
 keywords = ["streamstore", "s2", "log", "stream", "s3"]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Bump `streamstore-cli` version to 0.10.0 with a bug fix for `--create-stream-on-append` flag to accept explicit booleans.
> 
>   - **Version Update**:
>     - Bump version from `0.9.0` to `0.10.0` in `Cargo.toml` and `Cargo.lock`.
>   - **Bug Fixes**:
>     - Fix `--create-stream-on-append` to accept explicit boolean values as noted in `CHANGELOG.md`.
>   - **Changelog**:
>     - Add entry for version `0.10.0` on 2025-03-14 in `CHANGELOG.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=s2-streamstore%2Fs2-cli&utm_source=github&utm_medium=referral)<sup> for 3016b2ea2fd2b339c32a6ebefebd19a0533d45b4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->