### PR TITLE
fix: `create_stream_on_read` for reconfigure basin

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -201,7 +201,7 @@ enum Commands {
 
         /// Access permissions at the group level.
         /// The format is: "account=rw,basin=r,stream=w"
-        /// where 'r' indicates read permission and 'w' indicates write permission.        
+        /// where 'r' indicates read permission and 'w' indicates write permission.
         #[arg(long)]
         op_groups: Option<PermittedOperationGroups>,
 
@@ -845,6 +845,9 @@ async fn run() -> Result<(), S2CliError> {
             }
             if config.create_stream_on_append.is_some() {
                 mask.push("create_stream_on_append".to_owned());
+            }
+            if config.create_stream_on_read.is_some() {
+                mask.push("create_stream_on_read".to_owned());
             }
             let config: BasinConfig = account_service
                 .reconfigure_basin(basin.into(), config.into(), mask)

--- a/src/types.rs
+++ b/src/types.rs
@@ -146,19 +146,19 @@ pub struct BasinConfig {
     #[clap(flatten)]
     pub default_stream_config: Option<StreamConfig>,
     /// Create stream on append with basin defaults if it doesn't exist.
-    #[arg(short = 'a', long)]
+    #[arg(long)]
     pub create_stream_on_append: Option<bool>,
     /// Create stream on read with basin defaults if it doesn't exist.
-    #[arg(short = 'R', long)]
+    #[arg(long)]
     pub create_stream_on_read: Option<bool>,
 }
 
 #[derive(Parser, Debug, Clone, Serialize)]
 pub struct StreamConfig {
-    #[arg(short = 's', long)]
+    #[arg(long)]
     /// Storage class for a stream.
     pub storage_class: Option<StorageClass>,
-    #[arg(short = 'r', long, help("Example: 1d, 1w, 1y"))]
+    #[arg(long, help("Example: 1d, 1w, 1y"))]
     /// Retention policy for a stream.
     pub retention_policy: Option<RetentionPolicy>,
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -148,9 +148,8 @@ pub struct BasinConfig {
     /// Create stream on append with basin defaults if it doesn't exist.
     #[arg(short = 'a', long)]
     pub create_stream_on_append: Option<bool>,
-
     /// Create stream on read with basin defaults if it doesn't exist.
-    #[arg(short = 'r', long)]
+    #[arg(short = 'R', long)]
     pub create_stream_on_read: Option<bool>,
 }
 


### PR DESCRIPTION
Also change the short-hand for the option to `-R` since it clashed with `default_stream_config.retention_policy` (`-r`).