### PR TITLE
chore: updated `--format` names

### DIFF
--- a/src/formats.rs
+++ b/src/formats.rs
@@ -28,11 +28,11 @@ pub trait RecordWriter {
     ) -> io::Result<()>;
 }
 
-pub use text::Formatter as TextFormatter;
+pub use body::RawFormatter as RawBodyFormatter;
 pub type RawJsonFormatter = json::Formatter<false>;
 pub type Base64JsonFormatter = json::Formatter<true>;
 
-mod text {
+mod body {
     use std::{
         io,
         pin::Pin,
@@ -45,19 +45,19 @@ mod text {
 
     use super::{RecordParseError, RecordParser, RecordWriter};
 
-    pub struct Formatter;
+    pub struct RawFormatter;
 
-    impl RecordWriter for Formatter {
+    impl RecordWriter for RawFormatter {
         async fn write_record(
             record: &SequencedRecord,
             writer: &mut (impl AsyncWrite + Unpin),
         ) -> io::Result<()> {
             let s = String::from_utf8_lossy(&record.body);
-            writer.write_all(s.as_ref().as_bytes()).await
+            writer.write_all(s.as_bytes()).await
         }
     }
 
-    impl<I> RecordParser<I> for Formatter
+    impl<I> RecordParser<I> for RawFormatter
     where
         I: Stream<Item = io::Result<String>> + Send + Unpin,
     {

--- a/src/formats.rs
+++ b/src/formats.rs
@@ -29,8 +29,8 @@ pub trait RecordWriter {
 }
 
 pub use text::Formatter as TextFormatter;
-pub type JsonFormatter = json::Formatter<false>;
-pub type JsonBinsafeFormatter = json::Formatter<true>;
+pub type RawJsonFormatter = json::Formatter<false>;
+pub type Base64JsonFormatter = json::Formatter<true>;
 
 mod text {
     use std::{

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,8 @@
 use json_to_table::json_to_table;
 use std::{
-    fmt::Display,
     io::BufRead,
     path::PathBuf,
     pin::Pin,
-    str::FromStr,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
@@ -14,7 +12,7 @@ use clap::{Parser, Subcommand, ValueEnum, builder::styling};
 use colored::Colorize;
 use config::{config_path, create_config};
 use error::{S2CliError, ServiceError, ServiceErrorContext};
-use formats::{Base64JsonFormatter, RawJsonFormatter, RecordWriter, TextFormatter};
+use formats::{Base64JsonFormatter, RawBodyFormatter, RawJsonFormatter, RecordWriter};
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use ping::{LatencyStats, PingResult, Pinger};
 use rand::Rng;
@@ -478,43 +476,19 @@ enum ConfigActions {
 
 #[derive(Debug, Clone, Copy, Default, ValueEnum)]
 pub enum Format {
-    /// Record bodies with a potentially-lossy decoding as UTF-8.
-    /// Command records are skipped and sent to stderr.
+    /// Plaintext record body as UTF-8.
+    /// If the body is not valid UTF-8, this will be a lossy decoding.
+    /// Headers cannot be represented, so command records are sent to stderr when reading.
     #[default]
-    BodyOnly,
-    /// Newline delimited records in JSON format with UTF-8 headers and body.
-    Raw,
-    /// Newline delimited records in JSON format with headers and body encoded in Base64.
-    Base64,
-}
-
-impl Format {
-    fn as_str(&self) -> &str {
-        match self {
-            Self::BodyOnly => "",
-            Self::Raw => "raw",
-            Self::Base64 => "base64",
-        }
-    }
-}
-
-impl Display for Format {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(self.as_str())
-    }
-}
-
-impl FromStr for Format {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.trim().to_lowercase().as_str() {
-            "" => Ok(Self::BodyOnly),
-            "json" | "raw" => Ok(Self::Raw),
-            "json-binsafe" | "base64" => Ok(Self::Base64),
-            x => Err(format!("Unsupported format: {x}")),
-        }
-    }
+    #[clap(name = "")]
+    BodyRaw,
+    /// JSON format with UTF-8 headers and body.
+    /// If the data is not valid UTF-8, this will be a lossy decoding.
+    #[clap(name = "raw", alias = "json")]
+    JsonRaw,
+    /// JSON format with headers and body encoded as Base64.
+    #[clap(name = "base64", alias = "json-binsafe")]
+    JsonBase64,
 }
 
 #[derive(Debug, Clone)]
@@ -1041,9 +1015,13 @@ async fn run() -> Result<(), S2CliError> {
 
             let append_input_stream: Box<dyn Stream<Item = AppendRecord> + Send + Unpin> =
                 match format {
-                    Format::BodyOnly => Box::new(RecordStream::<_, TextFormatter>::new(records_in)),
-                    Format::Raw => Box::new(RecordStream::<_, RawJsonFormatter>::new(records_in)),
-                    Format::Base64 => {
+                    Format::BodyRaw => {
+                        Box::new(RecordStream::<_, RawBodyFormatter>::new(records_in))
+                    }
+                    Format::JsonRaw => {
+                        Box::new(RecordStream::<_, RawJsonFormatter>::new(records_in))
+                    }
+                    Format::JsonBase64 => {
                         Box::new(RecordStream::<_, Base64JsonFormatter>::new(records_in))
                     }
                 };
@@ -1413,48 +1391,51 @@ async fn handle_read_outputs(
                             };
                             for sequenced_record in sequenced_record_batch.records {
                                 batch_len += sequenced_record.metered_bytes();
-
-                                if let Some(command_record) = sequenced_record.as_command_record() {
-                                    let (cmd, description) = match command_record.command {
-                                        Command::Fence { fencing_token } => (
-                                            "fence",
-                                            format!(
-                                                "FencingToken({fencing_token})",
-                                            ),
-                                        ),
-                                        Command::Trim { seq_num } => (
-                                            "trim",
-                                            format!("TrimPoint({seq_num})"),
-                                        ),
-                                    };
-                                    eprintln!("{} with {}", cmd.bold(), description.green().bold());
-                                } else {
-                                    match format {
-                                        Format::BodyOnly => {
-                                            TextFormatter::write_record(
+                                match format {
+                                    Format::BodyRaw => {
+                                        if let Some(command_record) = sequenced_record.as_command_record() {
+                                            let (cmd, description) = match command_record.command {
+                                                Command::Fence { fencing_token } => (
+                                                    "fence",
+                                                    format!("FencingToken({fencing_token})")
+                                                ),
+                                                Command::Trim { seq_num } => (
+                                                    "trim",
+                                                    format!("TrimPoint({seq_num})"),
+                                                ),
+                                            };
+                                            eprintln!("{} with {} // {} @ {}",
+                                                cmd.bold(),
+                                                description.green().bold(),
+                                                sequenced_record.seq_num,
+                                                sequenced_record.timestamp
+                                            );
+                                            Ok(())
+                                        } else {
+                                            RawBodyFormatter::write_record(
                                                 &sequenced_record,
                                                 writer,
                                             ).await
-                                        },
-                                        Format::Raw => {
-                                            RawJsonFormatter::write_record(
-                                                &sequenced_record,
-                                                writer,
-                                            ).await
-                                        },
-                                        Format::Base64 => {
-                                            Base64JsonFormatter::write_record(
-                                                &sequenced_record,
-                                                writer,
-                                            ).await
-                                        },
-                                    }
-                                    .map_err(|e| S2CliError::RecordWrite(e.to_string()))?;
-                                    writer
-                                        .write_all(b"\n")
-                                        .await
-                                        .map_err(|e| S2CliError::RecordWrite(e.to_string()))?;
+                                        }
+                                    },
+                                    Format::JsonRaw => {
+                                        RawJsonFormatter::write_record(
+                                            &sequenced_record,
+                                            writer,
+                                        ).await
+                                    },
+                                    Format::JsonBase64 => {
+                                        Base64JsonFormatter::write_record(
+                                            &sequenced_record,
+                                            writer,
+                                        ).await
+                                    },
                                 }
+                                .map_err(|e| S2CliError::RecordWrite(e.to_string()))?;
+                                writer
+                                    .write_all(b"\n")
+                                    .await
+                                    .map_err(|e| S2CliError::RecordWrite(e.to_string()))?;
                             }
 
                             eprintln!(


### PR DESCRIPTION
old values still supported as aliases