### PR TITLE
feat: compress by default

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -574,10 +574,16 @@ fn parse_records_output_source(s: &str) -> Result<RecordsOut, std::io::Error> {
 
 fn client_config(access_token: String) -> Result<ClientConfig, S2CliError> {
     let endpoints = S2Endpoints::from_env().map_err(S2CliError::EndpointsFromEnv)?;
+    let disable_compression = std::env::var("S2_DISABLE_COMPRESSION")
+        .ok()
+        .and_then(|s| s.to_lowercase().parse::<bool>().ok())
+        .unwrap_or(false);
     let client_config = ClientConfig::new(access_token.to_string())
         .with_user_agent("s2-cli".parse().expect("valid user agent"))
         .with_endpoints(endpoints)
+        .with_compression(!disable_compression)
         .with_request_timeout(Duration::from_secs(30));
+    trace!(?client_config);
     Ok(client_config)
 }
 


### PR DESCRIPTION
Can make a big impact on streams with easily-compressible content.

Disable via boolean envvar `S2_DISABLE_COMPRESSION`.

E.g., comparing a read of 944MiB (metered) records, went from 19 seconds to 3 (from home ISP)

```console
% time S2_DISABLE_COMPRESSION=true ./target/release/s2 read s2://logs-macbook/system-standard -s 0 --count 1000000 > /dev/null
S2_DISABLE_COMPRESSION=true ./target/release/s2 read  -s 0 --count 1000000 >   4.23s user 4.57s system 45% cpu 19.318 total

% time ./target/release/s2 read s2://logs-macbook/system-standard -s 0 --count 1000000 > /dev/null
./target/release/s2 read s2://logs-macbook/system-standard -s 0 --count  >   1.04s user 0.71s system 58% cpu 2.969 total
```